### PR TITLE
Transition all background colors the same

### DIFF
--- a/client/sandbox/src/common/LightDarkToggle.less
+++ b/client/sandbox/src/common/LightDarkToggle.less
@@ -5,8 +5,6 @@
   border-radius: 10px;
   margin: 10px;
 
-  transition: background-color 0.25s;
-
   &:hover {
     background-color: var(--highlight-color);
   }

--- a/client/sandbox/src/common/better-router/BetterRoute.less
+++ b/client/sandbox/src/common/better-router/BetterRoute.less
@@ -1,7 +1,6 @@
 .better-route-link,
 .challenge-preview {
   background-color: var(--background-color);
-  transition: background-color 0.25s;
 }
 
 .better-route-link:hover,

--- a/client/sandbox/src/test-runner/App.less
+++ b/client/sandbox/src/test-runner/App.less
@@ -48,7 +48,6 @@ button {
   border: 1px solid var(--border-color);
   color: var(--link-color);
   border-radius: 10px;
-  transition: background-color 0.25s;
   cursor: pointer;
   padding: 5px;
 


### PR DESCRIPTION
Previously, some things didn't transition. They changed background color immediately, which was jarring.

I tried

```css
* {
  transition: background-color 0.25s;
}
```

but it still looked bad.

Easiest way to make everything consistent is to just have no transition.
