### PR TITLE
Wait for sync instead of on-evaluator-changes

### DIFF
--- a/client/sandbox/src/test-runner/TestRunner.tsx
+++ b/client/sandbox/src/test-runner/TestRunner.tsx
@@ -8,7 +8,7 @@ import { GraphState } from "@desmodder/graph-state";
 import {
   Calc,
   calcObjectToChallengeInterface,
-  waitForOnEvaluatorChangesEvents,
+  waitForSync,
 } from "../../../../shared/challenge-interface";
 import "./TestRunner.css";
 import { poll } from "../common/utils";
@@ -123,7 +123,7 @@ export function TestRunner(props: {
 
             const calc = (await getDesmos()).GraphingCalculator(inner, {});
             calc.setState(state.state);
-            await waitForOnEvaluatorChangesEvents(calc as Calc, 1);
+            await waitForSync(calc as Calc);
 
             setReferenceGraphs(
               new Map([


### PR DESCRIPTION
This fixes the problem of a graph having the same input as a test case, e.g. if the graph says `n=2` and a test case sets n=2. Then there's no change, so there's no evaluator change. But the evaluator does eventually sync up.
